### PR TITLE
fix c++11 w/ clang

### DIFF
--- a/src/scim_anthy_prefs.cpp
+++ b/src/scim_anthy_prefs.cpp
@@ -242,8 +242,8 @@ BoolConfigData config_bool_common [] =
     },
     {
         NULL,
-        "",
-        "",
+        false,
+        false,
         NULL,
         NULL,
         NULL,


### PR DESCRIPTION
Replace invalid empty‑string initializers with proper boolean values
```

scim_anthy_prefs.cpp:245:9: error: type 'const char[1]' cannot be narrowed to 'bool' in initializer list [-Wc++11-narrowing]
  245 |         "",
      |         ^~
scim_anthy_prefs.cpp:246:9: error: type 'const char[1]' cannot be narrowed to 'bool' in initializer list [-Wc++11-narrowing]
  246 |         "",
      |         ^~

```
Sry, I didn't test w/ clang before you released